### PR TITLE
Bổ sung tài liệu ngắn

### DIFF
--- a/notes/note.md
+++ b/notes/note.md
@@ -1,0 +1,4 @@
+# Ghi chú ngắn (2025-09-28 12:23 UTC)
+
+- Một số quan sát và lưu ý triển khai.
+- Tham khảo chi tiết trong mô tả PR.


### PR DESCRIPTION
Khắc phục lỗi build Windows do đường dẫn dài; bật longPathsEnable.